### PR TITLE
Use establish_connection instead of replace database.yml path

### DIFF
--- a/lib/tasks/multi_migrations_task.rake
+++ b/lib/tasks/multi_migrations_task.rake
@@ -1,3 +1,24 @@
+module MultiMigrations
+  def self.make_connection(db_name = nil)
+    raise "DATABASE is required" unless ENV['DATABASE']
+
+    connection_key = self.identify_configuration
+
+    raise "VALID DATABASE is required" unless connection_key
+
+    ActiveRecord::Base.establish_connection(connection_key)
+  end
+
+  def self.identify_configuration
+    if ActiveRecord::Base.configurations.has_key?("#{Rails.env}_#{ENV['DATABASE']}")
+      return "#{Rails.env}_#{ENV['DATABASE']}"
+    else
+      match = ActiveRecord::Base.configurations.find { |config| config[1]['database'] == ENV['DATABASE'] }
+      return match[0] unless match.nil?
+    end
+  end
+end
+
 namespace :db do
   namespace :multi do
     task :set_custom_db_config_paths do
@@ -7,7 +28,8 @@ namespace :db do
 
       Rails.application.config.paths['db/migrate'] = [Rails.root.join("db/migrate_#{database}").to_s]
       Rails.application.config.paths['db/seeds.rb'] = [Rails.root.join("db/seeds_#{database}.rb").to_s]
-      Rails.application.config.paths['config/database'] = [Rails.root.join("config/database_#{database}.yml").to_s]
+
+      MultiMigrations.make_connection database
     end
 
     multi_db_task = ->(name) {
@@ -17,8 +39,8 @@ namespace :db do
       end
     }
 
-    %w(drop create purge schema:load migrate migrate:reset reset rollback seed version
-   schema:dump structure:dump structure:load).each do |task_name|
+    (%w(drop create purge schema:load) + %w(migrate migrate:reset reset rollback seed version
+   schema:dump structure:dump structure:load)).each do |task_name|
       multi_db_task[task_name]
     end
   end


### PR DESCRIPTION
## Rails の設定の上書きだけでは複数 DB の migration に対応できないケースがある

依存する gem で ActiveRecord の拡張を `lazy_load_hook` を使わずに行っているものがあると、`ActiveRecord::Base.configuarions` の確定と `establish_connection` がデフォルトの DB 設定で実行されてしまう。

よって、`Rails.application.config.paths['config/database']` の設定を Rake Task で上書きする時点ではもう遅いということになってしまう。

よって、`establish_connection` で接続先を変更することで `db:migrate` 等を各 DB に振り分けることができる。

以下の実装を参考にしている。

https://github.com/azitabh/multi-database-migrations/blob/master/lib/multi-database-migrations/tasks/multi_database_migrations_tasks.rake
## create, drop 等ではどうするか

establish_connection が効かないため、`DATABASE_URL` の環境変数を利用する

```
$ DATABASE_URL="mysql2://root:root@localhost/user_dev"
```

ただし、test 環境の DB も一緒に作るという挙動を再現できないため development/test それぞれの DB で実行する必要がある。
